### PR TITLE
fix: detect production mode in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,8 @@ const webpack = require("webpack");
 const HtmlBundlerPlugin = require("html-bundler-webpack-plugin");
 const ImageMinimizerPlugin = require("image-minimizer-webpack-plugin");
 
-module.exports = ({ mode }) => {
+module.exports = (env, argv) => {
+  const { mode } = argv;
   const isProduction = mode === 'production';
 
   return {


### PR DESCRIPTION
Hello @mh8555,

> When I run the build cmd my images are not optimizing to the final build.

the problem was that the `isProduction` was always false because the `mode` option is in the second argument of the function.

Now, images will be optimised using `build` cmd, because the `ImageMinimizerPlugin` plugin take effect only if `isProduction` is true.